### PR TITLE
Fix issue with spaces in URL for curl

### DIFF
--- a/functions/wttr.fish
+++ b/functions/wttr.fish
@@ -3,6 +3,6 @@ function wttr -d "shows the weather to a given city eg. Rio de Janeiro"
     echo "Please install curl"
     return 5
   end
-  set url (echo $argv | sed -e 's/\ /%20/g')
+  set url (echo $argv | sed -E 's/\ /%20/g')
   curl -4 "https://wttr.in/$url"
 end

--- a/functions/wttr.fish
+++ b/functions/wttr.fish
@@ -3,5 +3,6 @@ function wttr -d "shows the weather to a given city eg. Rio de Janeiro"
     echo "Please install curl"
     return 5
   end
-  curl -4 "wttr.in/$argv"
+  set url (echo $argv | sed -e 's/\ /%20/g')
+  curl -4 "https://wttr.in/$url"
 end


### PR DESCRIPTION
Despite the URL being passed to curl being in double-quotes, still failed in the `fish` shell for me on Arch Linux. Figure a quick "replace spaces with '%20'" would do the trick (and does), so upstreaming the fix so others can benefit! 😄 